### PR TITLE
Update edit command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,24 +44,33 @@ dependencies {
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '17.0.7'
 
+    // JavaFX dependencies for all platforms
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    //implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac-aarch64' // ✅ Apple Silicon
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
+
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    //implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac-aarch64' // ✅ Apple Silicon
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
+
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    //implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac-aarch64' // ✅ Apple Silicon
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
+
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    //implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac-aarch64' // ✅ Apple Silicon
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 
+    // JSON Parsing Dependencies
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
+    // JUnit Testing
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
-
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
@@ -70,3 +79,4 @@ shadowJar {
 }
 
 defaultTasks 'clean', 'test'
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,13 +108,13 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [c/CCA]…�
 * Existing values will be updated to the input values.
 * When editing tags/CCAs, the existing tags/CCAs of the person will be removed i.e adding of tags/CCAs is not cumulative.
 * You can remove all the person’s tags or CCAs by typing `t/` or `c/` respectively 
-without specifying any tags after it.
+without specifying any tags/CCAs after it.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 *  `edit 4 c/` Clears all CCAs of the 4th person.
-*  `edit 3 c/football tennis badminton` Updates the 3rd person’s CCAs to football, tennis, and badminton, replacing any existing CCAs.
+*  `edit 3 c/football, tennis, badminton` Updates the 3rd person’s CCAs to football, tennis, and badminton, replacing any existing CCAs.
 
 ### Locating persons by name: `find`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,18 +101,20 @@ Format: `list`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [c/CCA]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
-* You can remove all the person’s tags by typing `t/` without
-    specifying any tags after it.
+* When editing tags/CCAs, the existing tags/CCAs of the person will be removed i.e adding of tags/CCAs is not cumulative.
+* You can remove all the person’s tags or CCAs by typing `t/` or `c/` respectively 
+without specifying any tags after it.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `edit 4 c/` Clears all CCAs of the 4th person.
+*  `edit 3 c/football tennis badminton` Updates the 3rd person’s CCAs to football, tennis, and badminton, replacing any existing CCAs.
 
 ### Locating persons by name: `find`
 
@@ -200,7 +202,7 @@ Action     | Format, Examples
 **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [c/CCA]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List**   | `list`
 **Help**   | `help`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.parallel=false
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
+org.gradle.jvmargs=-Djavafx.platform=mac-aarch64
+

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -45,6 +46,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_CCA + "CCA]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -101,7 +103,8 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        Set<Cca> updatedCcas = editPersonDescriptor.getCcas().orElse(personToEdit.getCcas());
+        Set<Cca> updatedCcas = editPersonDescriptor.getCcas().orElse(Collections.emptySet());
+
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedCcas);
     }
 
@@ -212,12 +215,8 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
-        /**
-         * Sets {@code ccas} to this object's {@code ccas}.
-         * A defensive copy of {@code ccas} is used internally.
-         */
         public void setCcas(Set<Cca> ccas) {
-            this.ccas = (ccas != null) ? new HashSet<>(ccas) : null;
+            this.ccas = (ccas != null) ? new HashSet<>(ccas) : new HashSet<>(); // Ensure it's a new set
         }
 
         /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -54,6 +54,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_CCA_NOT_FOUND = "At least one CCA in the person does not exist in the "
+            + "address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -86,7 +88,12 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.setPerson(personToEdit, editedPerson);
+        try {
+            model.setPerson(personToEdit, editedPerson);
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(MESSAGE_CCA_NOT_FOUND);
+        }
+
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -103,7 +103,7 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        Set<Cca> updatedCcas = editPersonDescriptor.getCcas().orElse(Collections.emptySet());
+        Set<Cca> updatedCcas = editPersonDescriptor.getCcas().orElse(personToEdit.getCcas());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedCcas);
     }
@@ -215,8 +215,12 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        // I had to change this code to ensure that when 'c/' is not provided the code doesn't
+        // do anything to the data
         public void setCcas(Set<Cca> ccas) {
-            this.ccas = (ccas != null) ? new HashSet<>(ccas) : new HashSet<>(); // Ensure it's a new set
+            if (ccas != null) {
+                this.ccas = new HashSet<>(ccas);
+            }
         }
 
         /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -36,7 +36,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_CCA);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_CCA);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -105,10 +105,12 @@ public class EditCommandParser implements Parser<EditCommand> {
             return Optional.of(Collections.emptySet()); // Clear all CCAs
         }
 
-        // Split multiple words into individual CCAs correctly
+        // Now splits CCAs by commas instead of spaces
         Set<Cca> ccaSet = ccas.stream()
-                .flatMap(cca -> Arrays.stream(cca.split("\\s+"))) // Splitting on whitespace
-                .map(name -> new Cca(new seedu.address.model.cca.CcaName(name))) // Ensure correct package import
+                .flatMap(cca -> Arrays.stream(cca.split("\\s*,\\s*"))) // Splitting by comma (`,`) with optional spaces
+                .map(String::trim) // Remove any extra spaces
+                .filter(name -> !name.isEmpty()) // Ensure no empty names
+                .map(name -> new Cca(new seedu.address.model.cca.CcaName(name))) // Convert to Cca objects
                 .collect(Collectors.toSet());
 
         return Optional.of(ccaSet);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,20 +3,24 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.cca.Cca;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -32,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_CCA);
 
         Index index;
 
@@ -58,9 +62,13 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
-        // TODO: implement parseCcasForEdit
+        if (argMultimap.getValue(PREFIX_CCA).isPresent()) {
+            parseCcasForEdit(argMultimap.getAllValues(PREFIX_CCA))
+                    .ifPresent(editPersonDescriptor::setCcas);
+        }
+
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -82,6 +90,27 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+    private Optional<Set<Cca>> parseCcasForEdit(Collection<String> ccas) throws ParseException {
+        assert ccas != null;
+
+        if (ccas.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Check if user entered only `c/` (empty input)
+        if (ccas.size() == 1 && ccas.contains("")) {
+            return Optional.of(Collections.emptySet()); // Clear all CCAs
+        }
+
+        // Split multiple words into individual CCAs correctly
+        Set<Cca> ccaSet = ccas.stream()
+                .flatMap(cca -> Arrays.stream(cca.split("\\s+"))) // Splitting on whitespace
+                .map(name -> new Cca(new seedu.address.model.cca.CcaName(name))) // Ensure correct package import
+                .collect(Collectors.toSet());
+
+        return Optional.of(ccaSet);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -25,9 +25,12 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
     /**
-     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
-     * trimmed.
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param oneBasedIndex The one-based index as a string.
+     * @return The corresponding {@code Index} object.
+     * @throws ParseException if the specified index is invalid (not a non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
@@ -41,6 +44,8 @@ public class ParserUtil {
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param name The string to be parsed as a name.
+     * @return A {@code Name} object.
      * @throws ParseException if the given {@code name} is invalid.
      */
     public static Name parseName(String name) throws ParseException {
@@ -56,6 +61,8 @@ public class ParserUtil {
      * Parses a {@code String phone} into a {@code Phone}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param phone The string to be parsed as a phone number.
+     * @return A {@code Phone} object.
      * @throws ParseException if the given {@code phone} is invalid.
      */
     public static Phone parsePhone(String phone) throws ParseException {
@@ -71,6 +78,8 @@ public class ParserUtil {
      * Parses a {@code String address} into an {@code Address}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param address The string to be parsed as an address.
+     * @return An {@code Address} object.
      * @throws ParseException if the given {@code address} is invalid.
      */
     public static Address parseAddress(String address) throws ParseException {
@@ -86,6 +95,8 @@ public class ParserUtil {
      * Parses a {@code String email} into an {@code Email}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param email The string to be parsed as an email.
+     * @return An {@code Email} object.
      * @throws ParseException if the given {@code email} is invalid.
      */
     public static Email parseEmail(String email) throws ParseException {
@@ -101,6 +112,8 @@ public class ParserUtil {
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param tag The string to be parsed as a tag.
+     * @return A {@code Tag} object.
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
@@ -113,7 +126,11 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     * Parses a {@code Collection<String>} into a {@code Set<Tag>}.
+     *
+     * @param tags The collection of tag names as strings.
+     * @return A set of {@code Tag} objects.
+     * @throws ParseException if any tag is invalid.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
@@ -124,12 +141,20 @@ public class ParserUtil {
         return tagSet;
     }
 
+    /**
+     * Parses a {@code Collection<String>} into a {@code Set<Cca>}.
+     *
+     * @param ccas The collection of CCA names as strings.
+     * @return A set of {@code Cca} objects.
+     * @throws ParseException if any CCA name is invalid.
+     */
     public static Set<Cca> parseCcas(Collection<String> ccas) throws ParseException {
+        requireNonNull(ccas);
         final Set<Cca> ccaSet = new HashSet<>();
         for (String ccaName : ccas) {
             ccaSet.add(new Cca(new CcaName(ccaName)));
         }
         return ccaSet;
     }
-
 }
+

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.cca.Cca;
+import seedu.address.model.cca.CcaName;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -121,4 +123,13 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    public static Set<Cca> parseCcas(Collection<String> ccas) throws ParseException {
+        final Set<Cca> ccaSet = new HashSet<>();
+        for (String ccaName : ccas) {
+            ccaSet.add(new Cca(new CcaName(ccaName)));
+        }
+        return ccaSet;
+    }
+
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -41,7 +42,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
-    private FlowPane ccas;
+    private Label ccas;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -57,8 +58,15 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        person.getCcas().stream()
-                .sorted(Comparator.comparing(cca -> cca.getCcaName().fullCcaName))
-                .forEach(cca -> ccas.getChildren().add(new Label(cca.getCcaName().fullCcaName)));
+        if (!person.getCcas().isEmpty()) {
+            String ccaText = person.getCcas().stream()
+                    .sorted(Comparator.comparing(cca -> cca.getCcaName().fullCcaName))
+                    .map(cca -> cca.getCcaName().fullCcaName)
+                    .collect(Collectors.joining(", "));
+            ccas.setText("CCAs: " + ccaText);
+        } else {
+            ccas.setText("No CCAs");
+        }
+
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,7 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <FlowPane fx:id="ccas" />
+      <Label fx:id="ccas" styleClass="cell_small_label" text="\$cca" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/commons/util/AppUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/AppUtilTest.java
@@ -3,14 +3,21 @@ package seedu.address.commons.util;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 
 public class AppUtilTest {
 
     @Test
-    public void getImage_exitingImage() {
+    public void getImage_existingImage() {
+        File file = new File("src/main/resources/images/address_book_32.png");
+        System.out.println("🔍 Checking File Path: " + file.getAbsolutePath());
+        System.out.println("✅ File Exists: " + file.exists());
+
         assertNotNull(AppUtil.getImage("/images/address_book_32.png"));
     }
+
 
     @Test
     public void getImage_nullGiven_throwsNullPointerException() {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -82,22 +82,36 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
+    // note that this test case is newly added to test that 'edit 1 c/' indeed removes all the CCAs that
+    // the 1sr person has. The original test is removed because it is no longer applicable.
+    // For the original test to pass it required that 'edit 1 c/' to not change anything in the first person
+    // which is not what we want
     @Test
-    public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_clearCcas_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // Ensure the person is visible
 
+        // Get the existing person and confirm that they have at least one CCA
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+        assertFalse(personInFilteredList.getCcas().isEmpty()); // Ensure CCAs exist before clearing
 
+        // Create an expected edited person with no CCAs
+        Person editedPerson = new PersonBuilder(personInFilteredList).withCcas().build(); // Empty CCAs
+
+        // Create the edit command with an empty CCA field (c/)
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withCcas().build()); // No args -> clear CCAs
+
+        // Expected success message
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
+        // Prepare expected model
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedPerson);
 
+        // Assert command success
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
+
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {


### PR DESCRIPTION
* Updated edit command to add CCA to student and delete CCA from student Eg. edit 4 c/ Clears all CCAs of the 4th person. edit 3 c/football tennis badminton Updates the 3rd person’s CCAs to football, tennis, and badminton, replacing any existing CCAs.
* Updated the UserGuide for edit command
* Updated the GUI to accomodate for the new CCA attribute
* Updated tests to suit new code
Fixes [#64](https://github.com/AY2425S2-CS2103T-T09-4/tp/issues/64)