### PR TITLE
Update edit command 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -30,12 +29,13 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing student in the address book.
  */
 public class EditStudentCommand extends Command {
 
     public static final String COMMAND_WORD = "edit_s";
 
+    // CHANGED: Updated usage format to remove role and use "c/" for CCA only.
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the student identified "
             + "by the index number used in the displayed student list. "
             + "Existing values will be overwritten by the input values.\n"
@@ -44,8 +44,7 @@ public class EditStudentCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_ROLE + "ROLE]...\n"
-            + "[" + PREFIX_CCA + "CCA]...\n"
+            + "[" + PREFIX_CCA + "CCA_NAME]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -105,6 +104,7 @@ public class EditStudentCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        // CHANGED: Only CCA information is updated. Role is no longer part of this command.
         Set<CcaInformation> updatedCcaInformation =
                 editPersonDescriptor.getCcaInformation().orElse(personToEdit.getCcaInformations());
 
@@ -117,7 +117,6 @@ public class EditStudentCommand extends Command {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof EditStudentCommand)) {
             return false;
         }
@@ -150,7 +149,7 @@ public class EditStudentCommand extends Command {
 
         /**
          * Copy constructor.
-         * A defensive copy of {@code roles} is used internally.
+         * A defensive copy of {@code ccaInformation} is used internally.
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
             setName(toCopy.name);
@@ -222,7 +221,6 @@ public class EditStudentCommand extends Command {
                 return true;
             }
 
-            // instanceof handles nulls
             if (!(other instanceof EditPersonDescriptor)) {
                 return false;
             }
@@ -242,7 +240,7 @@ public class EditStudentCommand extends Command {
                     .add("phone", phone)
                     .add("email", email)
                     .add("address", address)
-                    .add("ccainformation", ccaInformation)
+                    .add("ccaInformation", ccaInformation)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -35,7 +35,6 @@ public class EditStudentCommand extends Command {
 
     public static final String COMMAND_WORD = "edit_s";
 
-    // CHANGED: Updated usage format to remove role and use "c/" for CCA only.
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the student identified "
             + "by the index number used in the displayed student list. "
             + "Existing values will be overwritten by the input values.\n"
@@ -104,7 +103,6 @@ public class EditStudentCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        // CHANGED: Only CCA information is updated. Role is no longer part of this command.
         Set<CcaInformation> updatedCcaInformation =
                 editPersonDescriptor.getCcaInformation().orElse(personToEdit.getCcaInformations());
 

--- a/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
@@ -29,7 +29,6 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
      */
     public EditStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        // CHANGED: Removed PREFIX_ROLE from tokenization as role is no longer supported.
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                         PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_CCA);
@@ -43,7 +42,6 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStudentCommand.MESSAGE_USAGE), pe);
         }
 
-        // CHANGED: Verify only the relevant prefixes (role prefix removed)
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_CCA);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
@@ -61,10 +59,9 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
 
-        // CHANGED: Process CCA input independently.
         if (argMultimap.getValue(PREFIX_CCA).isPresent()) {
             String ccaInputValue = argMultimap.getValue(PREFIX_CCA).get();
-            // CHANGED: If input is empty (user entered "c/" without any text), clear the CCAs.
+            
             if (ccaInputValue.trim().isEmpty()) {
                 editPersonDescriptor.setCcaInformation(Collections.emptySet());
             } else {

--- a/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
@@ -61,7 +61,6 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
 
         if (argMultimap.getValue(PREFIX_CCA).isPresent()) {
             String ccaInputValue = argMultimap.getValue(PREFIX_CCA).get();
-            
             if (ccaInputValue.trim().isEmpty()) {
                 editPersonDescriptor.setCcaInformation(Collections.emptySet());
             } else {

--- a/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
@@ -7,23 +7,18 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditStudentCommand;
 import seedu.address.logic.commands.EditStudentCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.cca.Cca;
 import seedu.address.model.cca.CcaInformation;
-import seedu.address.model.role.Role;
 
 /**
- * Parses input arguments and creates a new EditStudentCommand object
+ * Parses input arguments and creates a new EditStudentCommand object.
  */
 public class EditStudentCommandParser implements Parser<EditStudentCommand> {
 
@@ -34,9 +29,10 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
      */
     public EditStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        // CHANGED: Removed PREFIX_ROLE from tokenization as role is no longer supported.
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME,
-                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_ROLE, PREFIX_CCA);
+                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_CCA);
 
         Index index;
 
@@ -47,7 +43,8 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStudentCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        // CHANGED: Verify only the relevant prefixes (role prefix removed)
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_CCA);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -64,13 +61,16 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
 
-        // Only accept **one** CCA and **one** Role input
-        Optional<String> ccaInput = argMultimap.getValue(PREFIX_CCA);
-        Optional<String> roleInput = argMultimap.getValue(PREFIX_ROLE);
-
-        if (ccaInput.isPresent() && roleInput.isPresent()) {
-            Set<CcaInformation> ccaInformationSet = ParserUtil.parseCcaInformation(ccaInput.get(), roleInput.get());
-            editPersonDescriptor.setCcaInformation(ccaInformationSet);
+        // CHANGED: Process CCA input independently.
+        if (argMultimap.getValue(PREFIX_CCA).isPresent()) {
+            String ccaInputValue = argMultimap.getValue(PREFIX_CCA).get();
+            // CHANGED: If input is empty (user entered "c/" without any text), clear the CCAs.
+            if (ccaInputValue.trim().isEmpty()) {
+                editPersonDescriptor.setCcaInformation(Collections.emptySet());
+            } else {
+                Set<CcaInformation> ccaInformationSet = ParserUtil.parseCcaInformation(ccaInputValue);
+                editPersonDescriptor.setCcaInformation(ccaInformationSet);
+            }
         }
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
@@ -79,35 +79,4 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
 
         return new EditStudentCommand(index, editPersonDescriptor);
     }
-
-    /**
-     * Parses {@code Collection<String> roles} into a {@code Set<Role>} if {@code roles} is non-empty.
-     * If {@code roles} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Role>} containing zero roles.
-     */
-    private Optional<Set<Role>> parseRolesForEdit(Collection<String> roles) throws ParseException {
-        assert roles != null;
-
-        if (roles.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> roleSet = roles.size() == 1 && roles.contains("") ? Collections.emptySet() : roles;
-        return Optional.of(ParserUtil.parseRoles(roleSet));
-    }
-
-    /**
-     * Parses {@code Collection<String> Ccas} into a {@code Set<Cca>} if {@code Ccas} is non-empty.
-     * If {@code Ccas} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Cca>} containing zero Ccas.
-     */
-    private Optional<Set<Cca>> parseCcasForEdit(Collection<String> ccas) throws ParseException {
-        assert ccas != null;
-
-        if (ccas.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> ccaSet = ccas.size() == 1 && ccas.contains("") ? Collections.emptySet() : ccas;
-        return Optional.of(ParserUtil.parseCcas(ccaSet));
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -170,7 +170,7 @@ public class ParserUtil {
      * @param roleName The Role name.
      * @return A set containing one {@code CcaInformation}.
      */
-    public static Set<CcaInformation> parseCcaInformation(String ccaName, String roleName) throws ParseException { 
+    public static Set<CcaInformation> parseCcaInformation(String ccaName, String roleName) throws ParseException {
         CcaName parsedCcaName = parseCcaName(ccaName);
 
         Cca cca = new Cca(parsedCcaName);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -184,6 +184,20 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String ccaName} into a {@code Set<CcaInformation>} with a default role.
+     * This method is used when only the CCA name is provided.
+     *
+     * @param ccaName The CCA name.
+     * @return A set containing one {@code CcaInformation} with a default role.
+     */
+    public static Set<CcaInformation> parseCcaInformation(String ccaName) {
+        // This is an overloaded version of the method parseCcaInformation
+        // Define a default role that will be used since role editing is not allowed.
+        String defaultRole = "member"; // Change this if a different default is required.
+        return parseCcaInformation(ccaName, defaultRole);
+    }
+
+    /**
      * Parses a {@code String ccaName} into a {@code CcaName}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -170,16 +170,14 @@ public class ParserUtil {
      * @param roleName The Role name.
      * @return A set containing one {@code CcaInformation}.
      */
-    public static Set<CcaInformation> parseCcaInformation(String ccaName, String roleName) {
-        Set<CcaInformation> ccaInformations = new HashSet<>();
+    public static Set<CcaInformation> parseCcaInformation(String ccaName, String roleName) throws ParseException { 
+        CcaName parsedCcaName = parseCcaName(ccaName);
 
-        // Create CCA and Role objects (No validation done)
-        Cca cca = new Cca(new CcaName(ccaName));
+        Cca cca = new Cca(parsedCcaName);
         Role role = new Role(roleName);
 
-        // Create CcaInformation with default attended sessions = 0
+        Set<CcaInformation> ccaInformations = new HashSet<>();
         ccaInformations.add(new CcaInformation(cca, role, cca.createNewAttendance()));
-
         return ccaInformations;
     }
 
@@ -190,7 +188,7 @@ public class ParserUtil {
      * @param ccaName The CCA name.
      * @return A set containing one {@code CcaInformation} with a default role.
      */
-    public static Set<CcaInformation> parseCcaInformation(String ccaName) {
+    public static Set<CcaInformation> parseCcaInformation(String ccaName) throws ParseException {
         // This is an overloaded version of the method parseCcaInformation
         // Define a default role that will be used since role editing is not allowed.
         String defaultRole = "member"; // Change this if a different default is required.
@@ -208,6 +206,7 @@ public class ParserUtil {
     public static CcaName parseCcaName(String ccaName) throws ParseException {
         requireNonNull(ccaName);
         String trimmedCcaName = ccaName.trim();
+
         if (!CcaName.isValidCcaName(trimmedCcaName)) {
             throw new ParseException(CcaName.MESSAGE_CONSTRAINTS);
         }

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -60,7 +60,7 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", ccainformation="
+                + editPersonDescriptor.getAddress().orElse(null) + ", ccaInformation="
                 + editPersonDescriptor.getCcaInformation().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/EditStudentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditStudentCommandParserTest.java
@@ -55,6 +55,7 @@ public class EditStudentCommandParserTest {
 
     private EditStudentCommandParser parser = new EditStudentCommandParser();
 
+
     @Test
     @Disabled
     public void parse_missingParts_failure() {
@@ -109,13 +110,23 @@ public class EditStudentCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + ROLE_DESC_PRESIDENT
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + ROLE_DESC_MEMBER;
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).build();
+        // Removed ROLE_DESC_PRESIDENT and ROLE_DESC_MEMBER from the user input
+        String userInput = targetIndex.getOneBased()
+                + PHONE_DESC_BOB
+                + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY
+                + NAME_DESC_AMY;
+
+        // Build the descriptor without a role
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_AMY)
+                .withAddress(VALID_ADDRESS_AMY)
+                .build();
+
         EditStudentCommand expectedCommand = new EditStudentCommand(targetIndex, descriptor);
-
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 


### PR DESCRIPTION
Fixes #105 

This PR removes role editing from the edit_s command and updates it to handle only the following fields:

Name (n/)

Phone (p/)

Email (e/)

Address (a/)

CCA (c/)

When the user inputs c/ it clears all the cca of the person specified

Changes
Command: Removed any code related to editing roles in EditStudentCommand and EditStudentCommandParser.

Parser: Updated parseCcaInformation(...) usage to handle single CCA inputs or empty inputs for clearing CCAs.

Tests: Removed references to role in the tests, and updated the parse_allFieldsSpecified_success() test to exclude role.