### PR TITLE
Removed redundant methods, comments and fixed methods with > 30 LOC

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCcaToStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCcaToStudentCommand.java
@@ -27,10 +27,8 @@ import seedu.address.model.role.Role;
  */
 public class AddCcaToStudentCommand extends Command {
 
-    /** The command word for adding a CCA to a student. */
     public static final String COMMAND_WORD = "add_c";
 
-    /** Usage message for the add_c command. */
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a CCA to the student identified "
             + "by the index number used in the displayed student list.\n"
             + "The CCA must already exist in the CCA list.\n"
@@ -39,20 +37,15 @@ public class AddCcaToStudentCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_CCA_NAME + "Basketball";
 
-    /** Success message displayed upon successful execution. */
     public static final String MESSAGE_ADD_CCA_SUCCESS = "Added CCA %2$s to student: %1$s";
-    /** Error message displayed if the student is already enrolled in the CCA. */
     public static final String MESSAGE_CCA_ALREADY_PRESENT = "This student is already enrolled in this CCA.";
 
     private final Index studentIndex;
     private final CcaName ccaName;
 
     /**
-     * Creates an AddCcaToStudentCommand to add the specified {@code CcaName}
-     *   to the student at the {@code studentIndex}.
-     *
-     * @param studentIndex index of the student in the filtered person list to add CCA to. Cannot be null.
-     * @param ccaName name of the CCA to add. Cannot be null.
+     * Creates an AddCcaToStudentCommand to add the specified {@code CcaName} to the student at
+     * the specified {@code studentIndex}.
      */
     public AddCcaToStudentCommand(Index studentIndex, CcaName ccaName) {
         requireAllNonNull(studentIndex, ccaName);
@@ -60,68 +53,37 @@ public class AddCcaToStudentCommand extends Command {
         this.ccaName = ccaName;
     }
 
-    /**
-     * Executes the command to add the specified CCA to the student.
-     * Finds the student and the CCA, checks for validity (index bounds, CCA existence, non-duplication),
-     * creates a new Person object with the added CCA information, updates the model, and returns a success message.
-     *
-     * @param model {@code Model} which the command should operate on. Cannot be null.
-     * @return feedback message of the operation result for display.
-     * @throws CommandException If an error occurs during command execution (e.g., invalid index,
-     *     CCA not found, student already has CCA).
-     */
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownPersonList = model.getFilteredPersonList();
 
-        // Check 1: Validate Student Index
         if (studentIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
-
         if (!model.hasCca(ccaName)) {
             throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
         }
 
         Person personToAddCca = lastShownPersonList.get(studentIndex.getZeroBased());
-        assert personToAddCca != null : "Person object should exist at the validated index.";
-
-        // Check 2: Find the target CCA in the model's CCA list
         Cca targetCca = model.getCca(ccaName);
-        assert targetCca != null : "Target Cca object should exist in the model.";
 
         if (personToAddCca.hasCca(targetCca)) {
             throw new CommandException(MESSAGE_CCA_ALREADY_PRESENT);
         }
 
-        CcaInformation newCcaInfo = new CcaInformation(targetCca,
-                Role.DEFAULT_ROLE,
-                targetCca.createNewAttendance());
-
+        CcaInformation newCcaInfo = new CcaInformation(targetCca, Role.DEFAULT_ROLE, targetCca.createNewAttendance());
         Set<CcaInformation> updatedCcaInformations = new HashSet<>(personToAddCca.getCcaInformations());
-        updatedCcaInformations.add(newCcaInfo);
 
+        updatedCcaInformations.add(newCcaInfo);
         Person personWithAddedCca = personToAddCca.addCca(newCcaInfo);
 
-        assert personWithAddedCca != null : "Newly created Person object should not be null.";
-        assert personWithAddedCca.hasCca(targetCca) : "Newly created Person should have the target CCA.";
-
         model.setPerson(personToAddCca, personWithAddedCca);
-
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_ADD_CCA_SUCCESS,
-                Messages.format(personWithAddedCca),
+        return new CommandResult(String.format(MESSAGE_ADD_CCA_SUCCESS, Messages.format(personWithAddedCca),
                 Messages.format(ccaName)));
     }
 
-    /**
-     * Checks if this command is equal to another object.
-     * Equality is based on the student index and the CCA name.
-     *
-     * @param other The object to compare against.
-     * @return true if the objects are the same or have the same index and CCA name, false otherwise.
-     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -139,11 +101,6 @@ public class AddCcaToStudentCommand extends Command {
                 && ccaName.equals(otherCommand.ccaName);
     }
 
-    /**
-     * Returns a string representation of the command, including the index and CCA name.
-     *
-     * @return A string representation of the object.
-     */
     @Override
     public String toString() {
         return new ToStringBuilder(this)

--- a/src/main/java/seedu/address/logic/commands/AddRoleToStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRoleToStudentCommand.java
@@ -64,35 +64,13 @@ public class AddRoleToStudentCommand extends Command {
         if (studentIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+
         Person personToAddRole = lastShownPersonList.get(studentIndex.getZeroBased());
-
-        if (!model.hasCca(ccaName)) {
-            throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
-        }
-        Cca targetCca = model.getCca(ccaName);
-
-        if (!personToAddRole.hasCca(targetCca)) {
-            throw new CommandException(Messages.MESSAGE_CCA_NOT_IN_PERSON);
-        }
-
-        if (!personToAddRole.isDefaultRoleInCca(targetCca)) {
-            throw new CommandException(MESSAGE_ROLE_ALREADY_ASSIGNED);
-        }
-
-        if (role.isDefaultRole()) {
-            throw new CommandException(MESSAGE_CANNOT_ASSIGN_DEFAULT_ROLE);
-        }
-
-        if (!targetCca.hasRole(role)) {
-            throw new CommandException(Messages.MESSAGE_ROLE_NOT_FOUND);
-        }
+        Cca targetCca = validateInputs(model, personToAddRole);
 
         Person personWithAddedRole = personToAddRole.addRole(targetCca, role);
-
         try {
-
             model.setPerson(personToAddRole, personWithAddedRole);
-
         } catch (IllegalArgumentException e) {
             throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
         }
@@ -100,6 +78,29 @@ public class AddRoleToStudentCommand extends Command {
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(
                 MESSAGE_ADD_ROLE_TO_STUDENT_SUCCESS, Messages.format(personWithAddedRole)));
+    }
+
+    /**
+     * Validates the inputs for adding a role to a student's CCA.
+     */
+    private Cca validateInputs(Model model, Person personToAddRole) throws CommandException {
+        if (!model.hasCca(ccaName)) {
+            throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
+        }
+        Cca targetCca = model.getCca(ccaName);
+        if (!personToAddRole.hasCca(targetCca)) {
+            throw new CommandException(Messages.MESSAGE_CCA_NOT_IN_PERSON);
+        }
+        if (!personToAddRole.isDefaultRoleInCca(targetCca)) {
+            throw new CommandException(MESSAGE_ROLE_ALREADY_ASSIGNED);
+        }
+        if (role.isDefaultRole()) {
+            throw new CommandException(MESSAGE_CANNOT_ASSIGN_DEFAULT_ROLE);
+        }
+        if (!targetCca.hasRole(role)) {
+            throw new CommandException(Messages.MESSAGE_ROLE_NOT_FOUND);
+        }
+        return targetCca;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CreateCcaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCcaCommand.java
@@ -26,7 +26,7 @@ public class CreateCcaCommand extends Command {
     private final Cca toCreate;
 
     /**
-     * Creates a CreateCcaCommand to add the specified {@code CCA}
+     * Creates a CreateCcaCommand to add the specified {@code CCA}.
      */
     public CreateCcaCommand(Cca cca) {
         requireNonNull(cca);

--- a/src/main/java/seedu/address/logic/commands/CreateStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateStudentCommand.java
@@ -25,15 +25,12 @@ public class CreateStudentCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_ROLE + "TAG]...\n"
+            + PREFIX_ADDRESS + "ADDRESS \n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_ROLE + "friends "
-            + PREFIX_ROLE + "owesMoney";
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the address book";
@@ -41,7 +38,7 @@ public class CreateStudentCommand extends Command {
     private final Person toCreate;
 
     /**
-     * Creates a CreateStudentCommand to add the specified {@code Person}
+     * Creates a CreateStudentCommand to add the specified {@code Person}.
      */
     public CreateStudentCommand(Person person) {
         requireNonNull(person);

--- a/src/main/java/seedu/address/logic/commands/CreateStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateStudentCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/DeleteCcaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCcaCommand.java
@@ -27,6 +27,9 @@ public class DeleteCcaCommand extends Command {
 
     private final Index targetIndex;
 
+    /**
+     * Creates a DeleteCcaCommand to delete the {@code Cca} specified by the index.
+     */
     public DeleteCcaCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteRoleFromStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRoleFromStudentCommand.java
@@ -54,34 +54,28 @@ public class DeleteRoleFromStudentCommand extends Command {
         if (studentIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
-        Person personToDeleteRole = lastShownPersonList.get(studentIndex.getZeroBased());
 
+        Person personToDeleteRole = lastShownPersonList.get(studentIndex.getZeroBased());
         if (!model.hasCca(ccaName)) {
             throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
         }
-        Cca targetCca = model.getCca(ccaName);
 
+        Cca targetCca = model.getCca(ccaName);
         if (!personToDeleteRole.hasCca(targetCca)) {
             throw new CommandException(Messages.MESSAGE_CCA_NOT_IN_PERSON);
         }
-
         if (personToDeleteRole.isDefaultRoleInCca(targetCca)) {
             throw new CommandException(MESSAGE_ROLE_NOT_ASSIGNED);
         }
 
         Person personWithDeletedRole = personToDeleteRole.deleteRole(targetCca);
-
         try {
-
             model.setPerson(personToDeleteRole, personWithDeletedRole);
-
         } catch (IllegalArgumentException e) {
             throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
         }
-
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(
-                String.format(MESSAGE_DELETE_ROLE_FROM_STUDENT_SUCCESS, personWithDeletedRole));
+        return new CommandResult(String.format(MESSAGE_DELETE_ROLE_FROM_STUDENT_SUCCESS, personWithDeletedRole));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
@@ -27,6 +27,9 @@ public class DeleteStudentCommand extends Command {
 
     private final Index targetIndex;
 
+    /**
+     * Creates a DeleteStudentCommand to delete the {@code Person} specified by the index.
+     */
     public DeleteStudentCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }

--- a/src/main/java/seedu/address/logic/commands/EditCcaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCcaCommand.java
@@ -50,8 +50,7 @@ public class EditCcaCommand extends Command {
     private final EditCcaDescriptor editCcaDescriptor;
 
     /**
-     * @param index of the cca in the cca list to edit
-     * @param editCcaDescriptor details to edit the student with
+     * Creates an EditCcaCommand to edit the {@code Cca} specified by the index.
      */
     public EditCcaCommand(Index index, EditCcaDescriptor editCcaDescriptor) {
         requireNonNull(index);

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -27,7 +27,6 @@ import seedu.address.model.person.Phone;
 
 /**
  * Edits the details of an existing student in the address book.
- * Does not allow editing of CCAs or Roles. Use add_c/remove_c and add_r/delete_r instead.
  */
 public class EditStudentCommand extends Command {
 
@@ -54,13 +53,11 @@ public class EditStudentCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the student in the filtered student list to edit
-     * @param editPersonDescriptor details to edit the student with
+     * Creates an EditStudentCommand to edit the {@code Person} specified by the index.
      */
     public EditStudentCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
-
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
@@ -82,7 +79,6 @@ public class EditStudentCommand extends Command {
         }
 
         if (!model.isValidPersonCcas(editedPerson)) {
-            // This exception indicates a CCA associated with the person doesn't exist in the AddressBook's CCA list.
             throw new CommandException(Messages.MESSAGE_CCA_NOT_FOUND);
         }
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -99,7 +99,6 @@ public class EditStudentCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        // Preserve original CCAs
         Set<CcaInformation> updatedCcaInformation = personToEdit.getCcaInformations();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCcaInformation);
@@ -146,14 +145,12 @@ public class EditStudentCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
-            // REMOVED: setCcaInformation(toCopy.ccaInformation);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            // REMOVED: ccaInformation from check
             return CollectionUtil.isAnyNonNull(name, phone, email, address);
         }
 
@@ -189,9 +186,6 @@ public class EditStudentCommand extends Command {
             return Optional.ofNullable(address);
         }
 
-        // REMOVED: setCcaInformation method
-        // REMOVED: getCcaInformation method
-
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -201,7 +195,6 @@ public class EditStudentCommand extends Command {
                 return false;
             }
             EditPersonDescriptor otherEditPersonDescriptor = (EditPersonDescriptor) other;
-            // REMOVED: ccaInformation from comparison
             return Objects.equals(name, otherEditPersonDescriptor.name)
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
@@ -210,7 +203,6 @@ public class EditStudentCommand extends Command {
 
         @Override
         public String toString() {
-            // REMOVED: ccaInformation from toString
             return new ToStringBuilder(this)
                     .add("name", name)
                     .add("phone", phone)

--- a/src/main/java/seedu/address/logic/commands/RecordAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordAttendanceCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.cca.CcaName;
 import seedu.address.model.person.Person;
 
 /**
- * Records the attendance of a member in a CCA.
+ * Records the attendance of a person in a CCA.
  */
 public class RecordAttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attend";

--- a/src/main/java/seedu/address/logic/commands/RemoveCcaFromStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCcaFromStudentCommand.java
@@ -36,8 +36,8 @@ public class RemoveCcaFromStudentCommand extends Command {
     private final CcaName ccaName;
 
     /**
-     * @param studentIndex of the student in the filtered student list to remove CCA from.
-     * @param ccaName of the CCA to remove.
+     * Creates a RemoveCcaFromStudentCommand to remove the specified {@code CcaName} from the student at
+     * the specified {@code studentIndex}.
      */
     public RemoveCcaFromStudentCommand(Index studentIndex, CcaName ccaName) {
         requireAllNonNull(studentIndex, ccaName);
@@ -70,8 +70,7 @@ public class RemoveCcaFromStudentCommand extends Command {
         model.setPerson(personToRemoveCca, personWithRemovedCca);
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_REMOVE_CCA_SUCCESS,
-                Messages.format(personWithRemovedCca),
+        return new CommandResult(String.format(MESSAGE_REMOVE_CCA_SUCCESS, Messages.format(personWithRemovedCca),
                 Messages.format(ccaName)));
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddCcaToStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCcaToStudentCommandParser.java
@@ -23,11 +23,9 @@ public class AddCcaToStudentCommandParser implements Parser<AddCcaToStudentComma
      */
     public AddCcaToStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME)
-                || argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME) || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(
                     MESSAGE_INVALID_COMMAND_FORMAT, AddCcaToStudentCommand.MESSAGE_USAGE));
         }
@@ -36,8 +34,8 @@ public class AddCcaToStudentCommandParser implements Parser<AddCcaToStudentComma
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCcaToStudentCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddCcaToStudentCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_CCA_NAME);

--- a/src/main/java/seedu/address/logic/parser/AddRoleToStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRoleToStudentCommandParser.java
@@ -25,11 +25,9 @@ public class AddRoleToStudentCommandParser implements Parser<AddRoleToStudentCom
      */
     public AddRoleToStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME, PREFIX_ROLE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME, PREFIX_ROLE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME, PREFIX_ROLE)
-                || argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME, PREFIX_ROLE) || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(
                     MESSAGE_INVALID_COMMAND_FORMAT, AddRoleToStudentCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -92,7 +92,6 @@ public class AddressBookParser {
             return new AddRoleToStudentCommandParser().parse(arguments);
 
         case DeleteRoleFromStudentCommand.COMMAND_WORD:
-            // Ensure the correct DeleteRoleFromStudentCommandParser is imported/used
             return new DeleteRoleFromStudentCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/CreateCcaCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCcaCommandParser.java
@@ -21,11 +21,9 @@ public class CreateCcaCommandParser implements Parser<CreateCcaCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public CreateCcaCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCcaCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/CreateStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateStudentCommandParser.java
@@ -35,7 +35,8 @@ public class CreateStudentCommandParser implements Parser<CreateStudentCommand> 
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateStudentCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, CreateStudentCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
@@ -44,7 +45,7 @@ public class CreateStudentCommandParser implements Parser<CreateStudentCommand> 
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
 
-        // it is an empty set as any cca list is always initialised without ccas
+        // It is an empty set as the cca list of a student is initialised without ccas
         Set<CcaInformation> ccaInformation = new HashSet<>();
 
         Person person = new Person(name, phone, email, address, ccaInformation);

--- a/src/main/java/seedu/address/logic/parser/DeleteRoleFromStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteRoleFromStudentCommandParser.java
@@ -23,11 +23,9 @@ public class DeleteRoleFromStudentCommandParser implements Parser<DeleteRoleFrom
      */
     public DeleteRoleFromStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME)
-                || argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_CCA_NAME) || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteRoleFromStudentCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/EditCcaCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCcaCommandParser.java
@@ -30,8 +30,7 @@ public class EditCcaCommandParser implements Parser<EditCcaCommand> {
     public EditCcaCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME,
-                        PREFIX_ROLE, PREFIX_TOTAL_SESSIONS);
+                ArgumentTokenizer.tokenize(args, PREFIX_CCA_NAME, PREFIX_ROLE, PREFIX_TOTAL_SESSIONS);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditStudentCommandParser.java
@@ -25,11 +25,9 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
     public EditStudentCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME,
-                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS); // REMOVED: PREFIX_CCA_NAME
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         Index index;
-
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
@@ -40,7 +38,6 @@ public class EditStudentCommandParser implements Parser<EditStudentCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/model/cca/CcaName.java
+++ b/src/main/java/seedu/address/model/cca/CcaName.java
@@ -13,12 +13,6 @@ public class CcaName {
             "Cca names must start with a letter, must not be empty or purely numeric, "
                     + "and can contain alphanumeric characters, whitespace and hyphens only."
                     + "Multiple words are allowed, but only one whitespace or hyphen is allowed between words.";
-
-    /*
-     * The string must start with a letter.
-     * After the first character, alphanumeric characters are allowed, including whitespace and hyphens.
-     * Multiple words are allowed, but only one whitespace or hyphen is allowed between words.
-     */
     public static final String VALIDATION_REGEX = "^[A-Za-z]+(?:[ -][A-Za-z0-9]+)*$";
 
     public final String fullCcaName;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -205,7 +205,8 @@ public class Person {
 
         Attendance newAttendance;
 
-        // Ensures sessions attended is less than the new cca total session count
+        // Ensures sessions attended is less than the new cca total session count, if not, manually lower attendance
+        // count to match that of the cca's total sessions
         if (currentAttendanceSessionCount.getSessionCount() > newCcaTotalSessionCount.getSessionCount()) {
             newAttendance = new Attendance(new SessionCount(newCcaTotalSessionCount.getSessionCount()),
                     newCcaTotalSessionCount);

--- a/src/main/java/seedu/address/model/role/Role.java
+++ b/src/main/java/seedu/address/model/role/Role.java
@@ -11,7 +11,6 @@ public class Role {
 
     public static final String MESSAGE_CONSTRAINTS = "Role names should be alphanumeric";
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9\\- ]+$"; // Allow hyphens and spaces
-    // TODO: change to Member when merged with Edit commnad.
     public static final String DEFAULT_ROLE_NAME = "Member";
 
     public static final Role DEFAULT_ROLE = new Role(DEFAULT_ROLE_NAME);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -56,26 +56,26 @@ public class SampleDataUtil {
         };
     }
 
-    public static Person[] getSamplePersons(ObservableList<Cca> uniqueCcaList) {
+    public static Person[] getSamplePersons(AddressBook sampleAb) {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                    getCcaInformationSet(uniqueCcaList, "Canoe", "Member", "5")),
+                    getCcaInformationSet(sampleAb, "Canoe", "Member", "5")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                    getCcaInformationSet(uniqueCcaList, "Basketball", "Vice-Captain", "10")),
+                    getCcaInformationSet(sampleAb, "Basketball", "Vice-Captain", "10")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                    getCcaInformationSet(uniqueCcaList, "Badminton", "Member", "10")),
+                    getCcaInformationSet(sampleAb, "Badminton", "Member", "10")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                    getCcaInformationSet(uniqueCcaList, "E Sports", "Vice-President", "4")),
+                    getCcaInformationSet(sampleAb, "E Sports", "Vice-President", "4")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                    getCcaInformationSet(uniqueCcaList, "Football", "Captain", "5")),
+                    getCcaInformationSet(sampleAb, "Football", "Captain", "5")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                    getCcaInformationSet(uniqueCcaList, "Dance", "President", "5"))
+                    getCcaInformationSet(sampleAb, "Dance", "President", "5"))
         };
     }
 
@@ -85,9 +85,7 @@ public class SampleDataUtil {
             sampleAb.addCca(sampleCca);
         }
 
-        ObservableList<Cca> uniqueCcaList = sampleAb.getCcaList();
-
-        for (Person samplePerson : getSamplePersons(uniqueCcaList)) {
+        for (Person samplePerson : getSamplePersons(sampleAb)) {
             sampleAb.addPerson(samplePerson);
         }
         return sampleAb;
@@ -95,18 +93,9 @@ public class SampleDataUtil {
 
     /**
      * Returns a set of CCA information objects based on the provided data.
-     *
-     * - **Checks if the CCA exists** in `uniqueCcaList` (compares names).
-     * - **Uses the existing CCA reference** if found.
-     * - **Checks if the role exists** in the CCA's role set.
-     * - **Retrieves total sessions** from the existing CCA instead of user input.
-     *
-     * @param uniqueCcaList The list of existing CCAs.
-     * @param ccaInformationData Alternating parameters: CCA Name, Role, Attended Sessions.
-     * @return A set of {@code CcaInformation} objects.
      */
     public static Set<CcaInformation> getCcaInformationSet(
-            ObservableList<Cca> uniqueCcaList, String... ccaInformationData) {
+            AddressBook sampleAb, String... ccaInformationData) {
 
         Set<CcaInformation> ccaInformationSet = new HashSet<>();
 
@@ -115,47 +104,14 @@ public class SampleDataUtil {
             String roleName = ccaInformationData[i + 1];
             int attendedSessions = Integer.parseInt(ccaInformationData[i + 2]);
 
-            Cca existingCca = getCcaByName(uniqueCcaList, new CcaName(ccaName));
+            Cca existingCca = sampleAb.getCca(new CcaName(ccaName));
             int totalSessions = existingCca.getTotalSessions().getSessionCount();
 
-            // Check if the role exists in the cca
-            Role roleReference = findRoleInCca(existingCca, roleName);
-
-            // Create Attendance object
+            Role role = new Role(roleName);
             Attendance attendance = new Attendance(new SessionCount(attendedSessions), new SessionCount(totalSessions));
-
-            // Create CcaInformation and add to the set
-            ccaInformationSet.add(new CcaInformation(existingCca, roleReference, attendance));
+            ccaInformationSet.add(new CcaInformation(existingCca, role, attendance));
         }
         return ccaInformationSet;
-    }
-
-    /**
-     * Retrieves a CCA by its name from the given list.
-     *
-     * @param ccaList The observable list of CCAs.
-     * @param ccaName The CCA name to search for.
-     * @return The matching {@code Cca} object if found, otherwise {@code null}.
-     */
-    public static Cca getCcaByName(ObservableList<Cca> ccaList, CcaName ccaName) {
-        return ccaList.stream()
-                .filter(cca -> cca.getCcaName().equals(ccaName))
-                .findFirst()
-                .orElse(null);
-    }
-
-    /**
-     * Finds a role in the given CCA.
-     *
-     * @param cca The CCA to search in.
-     * @param roleName The name of the role to find.
-     * @return The matching {@code Role} if found, otherwise {@code null}.
-     */
-    private static Role findRoleInCca(Cca cca, String roleName) {
-        return cca.getRoles().stream()
-                .filter(role -> role.roleName.equals(roleName))
-                .findFirst()
-                .orElse(null);
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javafx.collections.ObservableList;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.cca.Attendance;

--- a/src/main/java/seedu/address/storage/JsonAdaptedCcaInformation.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCcaInformation.java
@@ -20,7 +20,6 @@ class JsonAdaptedCcaInformation {
     private final JsonAdaptedCca cca;
     private final JsonAdaptedRole role;
     private final int attendedSessions;
-    private final int totalSessions;
 
     /**
      * Constructs a {@code JsonAdaptedCcaInformation} with the given details.
@@ -28,12 +27,10 @@ class JsonAdaptedCcaInformation {
     @JsonCreator
     public JsonAdaptedCcaInformation(@JsonProperty("cca") JsonAdaptedCca cca,
                                      @JsonProperty("role") JsonAdaptedRole role,
-                                     @JsonProperty("attendedSessions") int attendedSessions,
-                                     @JsonProperty("totalSessions") int totalSessions) {
+                                     @JsonProperty("attendedSessions") int attendedSessions) {
         this.cca = cca;
         this.role = role;
         this.attendedSessions = attendedSessions;
-        this.totalSessions = totalSessions;
     }
 
     /**
@@ -43,7 +40,6 @@ class JsonAdaptedCcaInformation {
         this.cca = new JsonAdaptedCca(source.getCca());
         this.role = new JsonAdaptedRole(source.getRole());
         this.attendedSessions = source.getAttendance().getSessionsAttended().getSessionCount();
-        this.totalSessions = source.getAttendance().getTotalSessions().getSessionCount();
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -28,11 +28,6 @@ class JsonAdaptedRole {
         roleName = source.roleName;
     }
 
-    @JsonValue
-    public String getRoleName() {
-        return roleName;
-    }
-
     /**
      * Converts this Jackson-friendly adapted role object into the model's {@code Role} object.
      *

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -28,6 +28,11 @@ class JsonAdaptedRole {
         roleName = source.roleName;
     }
 
+    @JsonValue
+    public String getRoleName() {
+        return roleName;
+    }
+
     /**
      * Converts this Jackson-friendly adapted role object into the model's {@code Role} object.
      *

--- a/src/test/java/seedu/address/logic/parser/DeleteStudentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteStudentCommandParserTest.java
@@ -16,7 +16,7 @@ import seedu.address.logic.commands.DeleteStudentCommand;
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */
-public class DeleteCommandParserTest {
+public class DeleteStudentCommandParserTest {
 
     private DeleteStudentCommandParser parser = new DeleteStudentCommandParser();
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -111,8 +111,7 @@ public class JsonAdaptedPersonTest {
         invalidCcaInformation.add(new JsonAdaptedCcaInformation(
                 new JsonAdaptedCca(INVALID_CCA_NAME, new ArrayList<>(), INVALID_TOTAL_SESSIONS),
                 new JsonAdaptedRole(INVALID_ROLE),
-                INVALID_ATTENDED_SESSIONS,
-                INVALID_TOTAL_SESSIONS)
+                INVALID_ATTENDED_SESSIONS)
         );
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidCcaInformation);


### PR DESCRIPTION
Fixes #157 
Fixes #160 
Fixes #161
Fixes #162

**After merging, make sure you delete addressbook.json and reload again. I removed a redundant totalsessions attribute that was present in jsonadaptedccainformation**

Renamed deletecommandparsertest to deletestudentcommandparsertest
Fixed most methods with > 30 LOC, removed redundant methods and removed redundant comments.
Methods in Addressbookparser, editstudentcommandparser and jsonadaptedperson method is > 30 LOC, but so was the original. Should we fix it?
JsonAdaptedRole.getRoleName() is unused, but in the original AB3 it was originally getTagName() but also unused. Remove?